### PR TITLE
Update Example for Request Interceptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,10 @@ export class UserApi extends Api {
         this.interceptors.request.use(param => {
             return {
                 ...param,
-                defaults: {
-                    headers: {
-                        ...param.headers,
-                        "Authorization": `Bearer ${this.getToken()}`
-                    },
-                }
+                headers: {
+                    ...param.headers,
+                    "Authorization": `Bearer ${this.getToken()}`
+                },
             }
         });
 
@@ -100,12 +98,10 @@ The request interceptor gets an [AxiosRequestConfig](https://github.com/axios/ax
         this.interceptors.request.use((param) => {
             return {
                 ...param,
-                defaults: {
-                    headers: {
-                        ...param.headers,
-                        "Authorization": `Bearer ${this.getToken()}`
-                    },
-                }
+                headers: {
+                    ...param.headers,
+                    "Authorization": `Bearer ${this.getToken()}`
+                },
             }
         }, (error) => {
             // handling error


### PR DESCRIPTION
The behavior of Axios [appears to be](https://github.com/axios/axios/blob/fa3673710ea6bb3f351b4790bb17998d2f01f342/lib/core/Axios.js#L37-L58) that on each call the defaults are merged with the config for the request, and then the interceptors are called. Therefore, if the Authorization header is added to the defaults, they will not be applied to the call. 

This updates the example to directly add the header in the call.